### PR TITLE
Bump to lutece-init 0.6 to simplify database initialization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         - ./.secrets/:/run/secrets/
 
     lutece-init:
-      image: jhulibraries/lutece-init:0.4
+      image: jhulibraries/lutece-init:0.6
       container_name: lutece-init
       env_file: .env
       depends_on:


### PR DESCRIPTION
The new lutece-init simplifies database initialization. If data/lutece.sql is present it is treated as a full database dump and loaded in. If not the default Lutece db initialization happens. No longer do both occur.

In order to test, try various ways of doing a "docker-compose up lutece-init" with data/lutece.sql present or not present and examine the log messages and behavior. Also take a look at the documentation in the lutece-init repo and see if it makes sense.

Closes #40 