### PR TITLE
Rename templates files from .html to .ftl - Related issue LUTECE:2283

### DIFF
--- a/webapp/WEB-INF/conf/config.properties
+++ b/webapp/WEB-INF/conf/config.properties
@@ -40,8 +40,8 @@ lutece.webapp.instance=default
 ################################################################################
 # Statistical optional inclusion
 lutece.statistical.include.enable=true
-lutece.statistical.include.template.head=/skin/site/statistical_include_head.html
-lutece.statistical.include.template=/skin/site/statistical_include.html
+lutece.statistical.include.template.head=/skin/site/statistical_include_head.ftl
+lutece.statistical.include.template=/skin/site/statistical_include.ftl
 lutece.statistical.site.id=0
 # PhpMyVisit Server
 lutece.statistical.server.url=


### PR DESCRIPTION
Some keys in the specific config.properties has to be changed due to the renaming of templates extensions.