### PR TITLE
Add forms plugin [In progress]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,18 @@
       <version>7.0.0-SNAPSHOT</version>
       <type>lutece-core</type>
     </dependency>
-
+    <dependency>
+      <groupId>fr.paris.lutece.plugins</groupId>
+      <artifactId>plugin-genericattributes</artifactId>
+      <version>2.1.2</version>
+      <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>plugin-mylutece</artifactId>
@@ -76,20 +87,37 @@
       <artifactId>plugin-appointment</artifactId>
       <version>2.2.0-SNAPSHOT</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>plugin-childpages</artifactId>
       <version>4.1.1</version>
     <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
- 
+
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>plugin-html</artifactId>
       <version>4.0.2-SNAPSHOT</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -97,6 +125,12 @@
       <artifactId>plugin-xpageportlet</artifactId>
       <version>1.0.2</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -104,49 +138,98 @@
       <artifactId>plugin-enroll</artifactId>
       <version>1.1.1-SNAPSHOT</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>plugin-workflow</artifactId>
       <version>5.0.1</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>library-workflow-core</artifactId>
       <version>1.2.4</version>
       <type>jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-    <dependency>
-      <groupId>fr.paris.lutece.plugins</groupId>
-      <artifactId>plugin-genericattributes</artifactId>
-      <version>2.1.2</version>
-      <type>lutece-plugin</type>
-    </dependency>
+
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>plugin-address</artifactId>
       <version>1.0.7-SNAPSHOT</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>module-address-autocomplete</artifactId>
       <version>1.0.6-SNAPSHOT</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>module-appointment-leaflet</artifactId>
       <version>2.0.4-SNAPSHOT</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>fr.paris.lutece.plugins</groupId>
       <artifactId>plugin-leaflet</artifactId>
       <version>1.0.1</version>
       <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>fr.paris.lutece.plugins</groupId>
+      <artifactId>plugin-forms</artifactId>
+      <version>2.2.2-SNAPSHOT</version>
+      <type>lutece-plugin</type>
+      <exclusions>
+        <exclusion>
+          <groupId>fr.paris.lutece</groupId>
+          <artifactId>lutece-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This pull request adds the forms plugin to the site. 

Note the awkward way some dependency issues with lutece 7 are worked around. Eventually when there is a release, this should be able to be fixed. Another awkwardness (which is not caused by the pr) is that `commons_bs4_materialkit.html` from lutece-core is overwritten with a version which modified the loaded javascript libraries. At the moment this is required by our 2.2.0 fork of the appointment plugin. The lutece-core macro loads moment at the end of the the page, but this conflicts with the loading order of javascript libraries such as fullcalendar in the appointment plugin. Eventually this should be fixed in a more reasonable way.

There are a number of issues. Some may be caused by problems upstream, some may be problems with our setup.

- Translation issues: Form management label in menu is “ManageForms”  not "Manage Forms". The form editing step needs a bunch of labels translated to English.

- The forms plugin tries to load the js library toastr from the wrong location. Attempts `/js/admin/jquery/plugins/toastr/toastr.min.js` but is actually `js/jquery/plugins/toastr/toastr.min.js`.

- Attempts to load `http://localhost:8080/js/admin/locales/bootstrap-flatpickr..js` because the macro to load flatpickr doesn’t handle `<@getRegional language=language />` returning an empty string

- Cannot load `/editor.css`. Does not exist in war. Cannot load `/page_template_styles.css`. File exists in `/css`. The root cause may be `./WEB-INF/templates/admin/plugins/forms/forms_commons.html` where `<#assign cssFiles="editor.css, page_template_styles.css" />`.

- Cannot select breadcrumb type when trying to make form. There are no option elements in the select. This prevents a form from being created.

- The forms plugin does not format date and time according to user locale. If that gets fixed, I suspect date and time need to be normalized when being serialized between the database and frontend.



